### PR TITLE
Fix building with DUB and static libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,5 @@
 	"authors": ["Robert burner Schadek"],
 	"license": "BSD",
 	"importPaths": ["std", "."],
-	"sourcePaths": ["std", "."],
-	"configurations" : [
-		{
-			"targetType": "sourceLibrary",
-			"name" : "library"
-		}
-	]
+	"sourcePaths": ["std", "."]
 }


### PR DESCRIPTION
**Summary**
I had link errors when building whatever using logger with DUB. Fixed by tweaking package.json

**To reproduce:** make a DUB project using logger >=0.0.1, then type "dub".
DUB version: v0.9.21
DMD version: v2.065

**Example of error messages:**

```
Error 42: Symbol Undefined _D3std6logger6Logger5errorMFNebAyaiAyaAyaAyaZC3std6logger6Logger (@trusted std.logger.Logger std.logger.Logger.error(bool, immutable(char)[], int, immutable(char)[], immutable(char)[], immutable(char)[]))
```

**Two possible fixes:**
1. remove the "configurations" key from package.json (I like it since DUB is able to see it's a library)
2. change "sourceLibrary" into just "library"
